### PR TITLE
Fix search filter bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -344,9 +344,12 @@ def update_map(statuses, cats, countries, affils, search):
         term = search.strip()
         text_mask = (
             df[["Name","Affiliation","Category","Country","City","Position"]]
-              .apply(lambda col: col.astype(str)
-                                 .str.contains(term, case=False, na=False),
-                     axis=1)
+              .apply(
+                  lambda col: col.astype(str)
+                                    .str.contains(term, case=False, na=False,
+                                                  regex=False),
+                  axis=1
+              )
               .any(axis=1)
         )
         m &= text_mask
@@ -443,9 +446,12 @@ def update_visible_table(bounds, statuses, cats, countries,
     if search:
         s = search.strip()
         mask = df[["Name","Affiliation","Category","Country","City","Position"]] \
-                  .apply(lambda col: col.astype(str)
-                                         .str.contains(s, case=False, na=False)
-                       , axis=1).any(axis=1)
+                  .apply(
+                      lambda col: col.astype(str)
+                                       .str.contains(s, case=False, na=False,
+                                                    regex=False),
+                      axis=1
+                  ).any(axis=1)
         m &= mask
 
     vis = df[m]


### PR DESCRIPTION
## Summary
- treat global search terms as literal strings to avoid regex behaviour

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e225959083269275416dfd903e2a